### PR TITLE
Optimize batched Pfaffian computation

### DIFF
--- a/external/c_interface/skpfa_batched.c
+++ b/external/c_interface/skpfa_batched.c
@@ -13,8 +13,6 @@
 extern "C" {
 #endif
 
-#define MAX(a,b) ((a) > (b) ? (a) : (b))
-
 // Helper function for block-wise matrix transposition
 static inline void transpose_block(const double *src, double *dst, int N, 
                                  int row_start, int col_start, 
@@ -65,6 +63,159 @@ static void transpose_matrix_complex(const doublecmplx *src, doublecmplx *dst, i
     }
 }
 
+typedef struct {
+    int n;
+    int ldim;
+    int lwork;
+    int *iwork;
+    double *work;
+} pfapack_workspace_d;
+
+static void pfapack_workspace_d_free(pfapack_workspace_d *ws) {
+    if (!ws) {
+        return;
+    }
+    free(ws->work);
+    free(ws->iwork);
+    ws->work = NULL;
+    ws->iwork = NULL;
+    ws->lwork = 0;
+    ws->n = 0;
+    ws->ldim = 0;
+}
+
+static int pfapack_workspace_d_init(
+    pfapack_workspace_d *ws,
+    int n,
+    char uplo,
+    char mthd,
+    double *a_scratch
+) {
+    if (!ws || !a_scratch) {
+        return -2;
+    }
+
+    ws->n = n;
+    ws->ldim = n;
+    ws->lwork = 0;
+    ws->iwork = NULL;
+    ws->work = NULL;
+
+    ws->iwork = (int *)malloc(sizeof(int) * (size_t)n);
+    if (!ws->iwork) {
+        return -100;
+    }
+
+    int info = 0;
+    int lwork_query = -1;
+    double qwork = 0.0;
+    double pfaff_dummy = 0.0;
+    PFAPACK_dskpfa(&uplo, &mthd, &n, a_scratch, &ws->ldim,
+                  &pfaff_dummy, ws->iwork, &qwork, &lwork_query, &info);
+    if (info) {
+        pfapack_workspace_d_free(ws);
+        return info;
+    }
+
+    ws->lwork = (int)qwork;
+    if (ws->lwork < 1) {
+        ws->lwork = 1;
+    }
+
+    ws->work = (double *)malloc(sizeof(double) * (size_t)ws->lwork);
+    if (!ws->work) {
+        ws->lwork = (mthd == 'P') ? 1 : (2 * n - 1);
+        ws->work = (double *)malloc(sizeof(double) * (size_t)ws->lwork);
+        if (!ws->work) {
+            pfapack_workspace_d_free(ws);
+            return -100;
+        }
+    }
+
+    return 0;
+}
+
+typedef struct {
+    int n;
+    int ldim;
+    int lwork;
+    int *iwork;
+    double *rwork;
+    doublecmplx *work;
+} pfapack_workspace_z;
+
+static void pfapack_workspace_z_free(pfapack_workspace_z *ws) {
+    if (!ws) {
+        return;
+    }
+    free(ws->work);
+    free(ws->rwork);
+    free(ws->iwork);
+    ws->work = NULL;
+    ws->rwork = NULL;
+    ws->iwork = NULL;
+    ws->lwork = 0;
+    ws->n = 0;
+    ws->ldim = 0;
+}
+
+static int pfapack_workspace_z_init(
+    pfapack_workspace_z *ws,
+    int n,
+    char uplo,
+    char mthd,
+    doublecmplx *a_scratch
+) {
+    if (!ws || !a_scratch) {
+        return -2;
+    }
+
+    ws->n = n;
+    ws->ldim = n;
+    ws->lwork = 0;
+    ws->iwork = NULL;
+    ws->rwork = NULL;
+    ws->work = NULL;
+
+    ws->iwork = (int *)malloc(sizeof(int) * (size_t)n);
+    if (!ws->iwork) {
+        return -100;
+    }
+    ws->rwork = (double *)malloc(sizeof(double) * (size_t)(n - 1));
+    if (!ws->rwork) {
+        pfapack_workspace_z_free(ws);
+        return -100;
+    }
+
+    int info = 0;
+    int lwork_query = -1;
+    doublecmplx qwork = 0.0;
+    doublecmplx pfaff_dummy = 0.0;
+    PFAPACK_zskpfa(&uplo, &mthd, &n, a_scratch, &ws->ldim,
+                   &pfaff_dummy, ws->iwork, &qwork, &lwork_query, ws->rwork, &info);
+    if (info) {
+        pfapack_workspace_z_free(ws);
+        return info;
+    }
+
+    ws->lwork = (int)real(qwork);
+    if (ws->lwork < 1) {
+        ws->lwork = 1;
+    }
+
+    ws->work = (doublecmplx *)malloc(sizeof(doublecmplx) * (size_t)ws->lwork);
+    if (!ws->work) {
+        ws->lwork = (mthd == 'P') ? 1 : (2 * n - 1);
+        ws->work = (doublecmplx *)malloc(sizeof(doublecmplx) * (size_t)ws->lwork);
+        if (!ws->work) {
+            pfapack_workspace_z_free(ws);
+            return -100;
+        }
+    }
+
+    return 0;
+}
+
 int skpfa_batched_d(int batch_size, int N, double *A_batch, double *PFAFF_batch,
                     const char *UPLO, const char *MTHD)
 {
@@ -80,25 +231,36 @@ int skpfa_batched_d(int batch_size, int N, double *A_batch, double *PFAFF_batch,
 
     if (N > 0) {
         // Single workspace allocation for the entire batch
-        double *A_work = (double *)malloc(N * N * sizeof(double));
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        double *A_work = (double *)malloc(matrix_elems * sizeof(double));
         if (!A_work) return -100;
-        
+
+        pfapack_workspace_d ws;
+        int ws_ret = pfapack_workspace_d_init(&ws, N, uplo, mthd, A_work);
+        if (ws_ret != 0) {
+            free(A_work);
+            return ws_ret;
+        }
+
         for (int i = 0; i < batch_size; i++) {
             // Get pointer to current matrix in batch
-            double *A = A_batch + i * N * N;
+            double *A = A_batch + (size_t)i * matrix_elems;
             
             // Convert from C to Fortran order using block transposition
             transpose_matrix(A, A_work, N);
             
             // Compute Pfaffian
-            int ret = skpfa_d(N, A_work, &PFAFF_batch[i], UPLO, MTHD);
-            
-            if (ret != 0) {
+            int info = 0;
+            PFAPACK_dskpfa(&uplo, &mthd, &N, A_work, &ws.ldim, &PFAFF_batch[i],
+                           ws.iwork, ws.work, &ws.lwork, &info);
+            if (info) {
+                pfapack_workspace_d_free(&ws);
                 free(A_work);
-                return ret;
+                return info;
             }
         }
-        
+
+        pfapack_workspace_d_free(&ws);
         free(A_work);
     } else {
         // Handle empty matrix case
@@ -125,25 +287,36 @@ int skpfa_batched_z(int batch_size, int N, doublecmplx *A_batch, doublecmplx *PF
 
     if (N > 0) {
         // Single workspace allocation for the entire batch
-        doublecmplx *A_work = (doublecmplx *)malloc(N * N * sizeof(doublecmplx));
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        doublecmplx *A_work = (doublecmplx *)malloc(matrix_elems * sizeof(doublecmplx));
         if (!A_work) return -100;
-        
+
+        pfapack_workspace_z ws;
+        int ws_ret = pfapack_workspace_z_init(&ws, N, uplo, mthd, A_work);
+        if (ws_ret != 0) {
+            free(A_work);
+            return ws_ret;
+        }
+
         for (int i = 0; i < batch_size; i++) {
             // Get pointer to current matrix in batch
-            doublecmplx *A = A_batch + i * N * N;
+            doublecmplx *A = A_batch + (size_t)i * matrix_elems;
             
             // Convert from C to Fortran order using block transposition
             transpose_matrix_complex(A, A_work, N);
             
             // Compute Pfaffian
-            int ret = skpfa_z(N, A_work, &PFAFF_batch[i], UPLO, MTHD);
-            
-            if (ret != 0) {
+            int info = 0;
+            PFAPACK_zskpfa(&uplo, &mthd, &N, A_work, &ws.ldim, &PFAFF_batch[i],
+                           ws.iwork, ws.work, &ws.lwork, ws.rwork, &info);
+            if (info) {
+                pfapack_workspace_z_free(&ws);
                 free(A_work);
-                return ret;
+                return info;
             }
         }
-        
+
+        pfapack_workspace_z_free(&ws);
         free(A_work);
     } else {
         // Handle empty matrix case
@@ -171,26 +344,38 @@ int skpfa_batched_4d_d(int outer_batch_size, int inner_batch_size, int N,
 
     if (N > 0) {
         // Single workspace allocation for the entire batch
-        double *A_work = (double *)malloc(N * N * sizeof(double));
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        double *A_work = (double *)malloc(matrix_elems * sizeof(double));
         if (!A_work) return -100;
+
+        pfapack_workspace_d ws;
+        int ws_ret = pfapack_workspace_d_init(&ws, N, uplo, mthd, A_work);
+        if (ws_ret != 0) {
+            free(A_work);
+            return ws_ret;
+        }
 
         // Process each matrix in the batch
         const int total_matrices = outer_batch_size * inner_batch_size;
         for (int idx = 0; idx < total_matrices; idx++) {
             // Get pointers to current matrix and output
-            double *A = A_batch + idx * N * N;
+            double *A = A_batch + (size_t)idx * matrix_elems;
 
             // Convert from C to Fortran order using block transposition
             transpose_matrix(A, A_work, N);
 
             // Compute Pfaffian
-            int ret = skpfa_d(N, A_work, &PFAFF_batch[idx], UPLO, MTHD);
-            if (ret != 0) {
+            int info = 0;
+            PFAPACK_dskpfa(&uplo, &mthd, &N, A_work, &ws.ldim, &PFAFF_batch[idx],
+                           ws.iwork, ws.work, &ws.lwork, &info);
+            if (info) {
+                pfapack_workspace_d_free(&ws);
                 free(A_work);
-                return ret;
+                return info;
             }
         }
 
+        pfapack_workspace_d_free(&ws);
         free(A_work);
     }
     else {
@@ -220,26 +405,38 @@ int skpfa_batched_4d_z(int outer_batch_size, int inner_batch_size, int N,
 
     if (N > 0) {
         // Single workspace allocation for the entire batch
-        doublecmplx *A_work = (doublecmplx *)malloc(N * N * sizeof(doublecmplx));
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        doublecmplx *A_work = (doublecmplx *)malloc(matrix_elems * sizeof(doublecmplx));
         if (!A_work) return -100;
+
+        pfapack_workspace_z ws;
+        int ws_ret = pfapack_workspace_z_init(&ws, N, uplo, mthd, A_work);
+        if (ws_ret != 0) {
+            free(A_work);
+            return ws_ret;
+        }
 
         // Process each matrix in the batch
         const int total_matrices = outer_batch_size * inner_batch_size;
         for (int idx = 0; idx < total_matrices; idx++) {
             // Get pointers to current matrix and output
-            doublecmplx *A = A_batch + idx * N * N;
+            doublecmplx *A = A_batch + (size_t)idx * matrix_elems;
 
             // Convert from C to Fortran order using block transposition
             transpose_matrix_complex(A, A_work, N);
 
             // Compute Pfaffian
-            int ret = skpfa_z(N, A_work, &PFAFF_batch[idx], UPLO, MTHD);
-            if (ret != 0) {
+            int info = 0;
+            PFAPACK_zskpfa(&uplo, &mthd, &N, A_work, &ws.ldim, &PFAFF_batch[idx],
+                           ws.iwork, ws.work, &ws.lwork, ws.rwork, &info);
+            if (info) {
+                pfapack_workspace_z_free(&ws);
                 free(A_work);
-                return ret;
+                return info;
             }
         }
 
+        pfapack_workspace_z_free(&ws);
         free(A_work);
     }
     else {
@@ -267,24 +464,35 @@ int skpfa_batched_4d_d_f(int outer_batch_size, int inner_batch_size, int N,
     if (mthd != 'P' && mthd != 'H') return -5;
 
     if (N > 0) {
-        double *A_work = (double *)malloc((size_t)N * N * sizeof(double));
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        double *A_work = (double *)malloc(matrix_elems * sizeof(double));
         if (!A_work) return -100;
 
+        pfapack_workspace_d ws;
+        int ws_ret = pfapack_workspace_d_init(&ws, N, uplo, mthd, A_work);
+        if (ws_ret != 0) {
+            free(A_work);
+            return ws_ret;
+        }
+
         const int total_matrices = outer_batch_size * inner_batch_size;
-        const size_t matrix_elems = (size_t)N * N;
         const size_t matrix_bytes = matrix_elems * sizeof(double);
 
         for (int idx = 0; idx < total_matrices; idx++) {
-            double *A = A_batch + idx * matrix_elems;
+            double *A = A_batch + (size_t)idx * matrix_elems;
             memcpy(A_work, A, matrix_bytes);
 
-            int ret = skpfa_d(N, A_work, &PFAFF_batch[idx], UPLO, MTHD);
-            if (ret != 0) {
+            int info = 0;
+            PFAPACK_dskpfa(&uplo, &mthd, &N, A_work, &ws.ldim, &PFAFF_batch[idx],
+                           ws.iwork, ws.work, &ws.lwork, &info);
+            if (info) {
+                pfapack_workspace_d_free(&ws);
                 free(A_work);
-                return ret;
+                return info;
             }
         }
 
+        pfapack_workspace_d_free(&ws);
         free(A_work);
     }
     else {
@@ -311,24 +519,35 @@ int skpfa_batched_4d_z_f(int outer_batch_size, int inner_batch_size, int N,
     if (mthd != 'P' && mthd != 'H') return -5;
 
     if (N > 0) {
-        doublecmplx *A_work = (doublecmplx *)malloc((size_t)N * N * sizeof(doublecmplx));
+        const size_t matrix_elems = (size_t)N * (size_t)N;
+        doublecmplx *A_work = (doublecmplx *)malloc(matrix_elems * sizeof(doublecmplx));
         if (!A_work) return -100;
 
+        pfapack_workspace_z ws;
+        int ws_ret = pfapack_workspace_z_init(&ws, N, uplo, mthd, A_work);
+        if (ws_ret != 0) {
+            free(A_work);
+            return ws_ret;
+        }
+
         const int total_matrices = outer_batch_size * inner_batch_size;
-        const size_t matrix_elems = (size_t)N * N;
         const size_t matrix_bytes = matrix_elems * sizeof(doublecmplx);
 
         for (int idx = 0; idx < total_matrices; idx++) {
-            doublecmplx *A = A_batch + idx * matrix_elems;
+            doublecmplx *A = A_batch + (size_t)idx * matrix_elems;
             memcpy(A_work, A, matrix_bytes);
 
-            int ret = skpfa_z(N, A_work, &PFAFF_batch[idx], UPLO, MTHD);
-            if (ret != 0) {
+            int info = 0;
+            PFAPACK_zskpfa(&uplo, &mthd, &N, A_work, &ws.ldim, &PFAFF_batch[idx],
+                           ws.iwork, ws.work, &ws.lwork, ws.rwork, &info);
+            if (info) {
+                pfapack_workspace_z_free(&ws);
                 free(A_work);
-                return ret;
+                return info;
             }
         }
 
+        pfapack_workspace_z_free(&ws);
         free(A_work);
     }
     else {
@@ -350,6 +569,7 @@ int skpfa_batched_4d_z_with_inverse(
 {
     char uplo = toupper(UPLO[0]);
     char mthd = toupper(MTHD[0]);
+    const char uplo_pfa = (uplo == 'U') ? 'L' : 'U';
 
     // Input validation
     if (N < 0) return -1;
@@ -371,10 +591,10 @@ int skpfa_batched_4d_z_with_inverse(
     const size_t total_matrices = (size_t)outer_batch_size * inner_batch_size;
     const size_t matrix_size = (size_t)N * N;
 
-    // Step 1: Allocate initial buffer for work_matrix, work_pfaffian, ipiv, iwork, rwork
-    size_t initial_buffer_size = 
-        sizeof(doublecmplx) * 2 * matrix_size + // work_matrix and work_pfaffian
-        sizeof(int) * 2 * N +                  // ipiv and iwork
+    // Allocate buffer for work_pfaffian, ipiv, iwork, rwork
+    size_t initial_buffer_size =
+        sizeof(doublecmplx) * matrix_size +   // work_pfaffian
+        sizeof(int) * 2 * N +                 // ipiv and iwork
         sizeof(double) * (N - 1);             // rwork
 
     void *initial_buffer = NULL;
@@ -382,8 +602,7 @@ int skpfa_batched_4d_z_with_inverse(
         return -100;
 
     // Partition the buffer
-    doublecmplx *work_matrix = (doublecmplx *)initial_buffer;
-    doublecmplx *work_pfaffian = work_matrix + matrix_size;
+    doublecmplx *work_pfaffian = (doublecmplx *)initial_buffer;
     int *ipiv = (int *)(work_pfaffian + matrix_size);
     int *iwork = ipiv + N;
     double *rwork = (double *)(iwork + N);
@@ -398,7 +617,7 @@ int skpfa_batched_4d_z_with_inverse(
     int ldim = N;
 
     // Query optimal workspace for Pfaffian
-    PFAPACK_zskpfa(&uplo, &mthd, &N, work_pfaffian, &ldim, &qwork_pf,
+    PFAPACK_zskpfa(&uplo_pfa, &mthd, &N, work_pfaffian, &ldim, &qwork_pf,
                   iwork, &qwork_pf, &lwork_pf, rwork, &info);
     if (info != 0) {
         free(initial_buffer);
@@ -406,7 +625,7 @@ int skpfa_batched_4d_z_with_inverse(
     }
 
     // Query optimal workspace for inverse
-    zgetri_(&N, work_matrix, &ldim, ipiv, &qwork_inv, &lwork_inv, &info);
+    zgetri_(&N, work_pfaffian, &ldim, ipiv, &qwork_inv, &lwork_inv, &info);
     if (info != 0) {
         free(initial_buffer);
         return info;
@@ -427,11 +646,14 @@ int skpfa_batched_4d_z_with_inverse(
         doublecmplx *current_matrix = A_batch + idx * matrix_size;
         doublecmplx *current_inverse = inverses + idx * matrix_size;
 
-        // Transpose matrix for Pfaffian computation
-        transpose_matrix_complex(current_matrix, work_pfaffian, N);
+        // Fast path: avoid the explicit transpose by passing row-major data to
+        // the column-major PFAPACK kernel. This makes PFAPACK interpret the
+        // matrix as A^T = -A (skew-symmetric), so we swap UPLO and apply the
+        // Pfaffian sign correction below.
+        memcpy(work_pfaffian, current_matrix, matrix_size * sizeof(doublecmplx));
 
         // Compute Pfaffian
-        PFAPACK_zskpfa(&uplo, &mthd, &N, work_pfaffian, &ldim, &pfaffians[idx],
+        PFAPACK_zskpfa(&uplo_pfa, &mthd, &N, work_pfaffian, &ldim, &pfaffians[idx],
                       iwork, work, &lwork, rwork, &info);
         if (info != 0) {
             free(work);
@@ -439,20 +661,29 @@ int skpfa_batched_4d_z_with_inverse(
             return info;
         }
 
+        // Sign correction: pf(-A) = (-1)^(N/2) * pf(A), needed because we pass
+        // row-major data to column-major PFAPACK which interprets A as A^T = -A.
+        if (((N / 2) & 1) != 0) {
+            pfaffians[idx] = -pfaffians[idx];
+        }
+
         if (cabs(pfaffians[idx]) > 1e-12) {
+            // Build the inversion input in-place in the output buffer (or in-place on A_batch
+            // when called with inplace=True in Python).
+            if (current_inverse != current_matrix) {
+                memcpy(current_inverse, current_matrix, matrix_size * sizeof(doublecmplx));
+            }
 
-            // Transpose matrix again for inverse computation
-            transpose_matrix_complex(current_matrix, work_matrix, N);
-
-            // Ensure the full matrix is filled (assuming skew-symmetric property)
+            // Ensure the full matrix is filled (assuming skew-symmetric property).
             for (int i = 0; i < N; i++) {
                 for (int j = i + 1; j < N; j++) {
-                    work_matrix[j + i * N] = -work_matrix[i + j * N];
+                    current_inverse[(size_t)j * (size_t)N + (size_t)i] =
+                        -current_inverse[(size_t)i * (size_t)N + (size_t)j];
                 }
             }
 
-            // Compute LU decomposition
-            zgetrf_(&N, &N, work_matrix, &ldim, ipiv, &info);
+            // Compute LU decomposition and inverse in-place.
+            zgetrf_(&N, &N, current_inverse, &ldim, ipiv, &info);
             if (info != 0) {
                 free(work);
                 free(initial_buffer);
@@ -460,17 +691,15 @@ int skpfa_batched_4d_z_with_inverse(
             }
 
             // Compute inverse
-            zgetri_(&N, work_matrix, &ldim, ipiv, work, &lwork, &info);
+            zgetri_(&N, current_inverse, &ldim, ipiv, work, &lwork, &info);
             if (info != 0) {
                 free(work);
                 free(initial_buffer);
                 return info;
             }
-
-            // Transpose back the inverse to C order
-            transpose_matrix_complex(work_matrix, current_inverse, N);
+        } else {
+            memset(current_inverse, 0, matrix_size * sizeof(doublecmplx));
         }
-
     }
 
     // Cleanup
@@ -489,6 +718,7 @@ int skpfa_batched_4d_d_with_inverse(
 {
     char uplo = toupper(UPLO[0]);
     char mthd = toupper(MTHD[0]);
+    const char uplo_pfa = (uplo == 'U') ? 'L' : 'U';
 
     // Input validation
     if (N < 0) return -1;
@@ -510,18 +740,17 @@ int skpfa_batched_4d_d_with_inverse(
     const size_t total_matrices = (size_t)outer_batch_size * inner_batch_size;
     const size_t matrix_size = (size_t)N * N;
 
-    // Step 1: Allocate initial buffer for work_matrix, work_pfaffian, ipiv, iwork
-    size_t initial_buffer_size = 
-        sizeof(double) * 2 * matrix_size + // work_matrix and work_pfaffian
-        sizeof(int) * 2 * N;               // ipiv and iwork
+    // Allocate buffer for work_pfaffian, ipiv, iwork
+    size_t initial_buffer_size =
+        sizeof(double) * matrix_size +    // work_pfaffian
+        sizeof(int) * 2 * N;              // ipiv and iwork
 
     void *initial_buffer = NULL;
     if (posix_memalign(&initial_buffer, 64, initial_buffer_size) != 0)
         return -100;
 
     // Partition the buffer
-    double *work_matrix = (double *)initial_buffer;
-    double *work_pfaffian = work_matrix + matrix_size;
+    double *work_pfaffian = (double *)initial_buffer;
     int *ipiv = (int *)(work_pfaffian + matrix_size);
     int *iwork = ipiv + N;
 
@@ -535,7 +764,7 @@ int skpfa_batched_4d_d_with_inverse(
     int ldim = N;
 
     // Query optimal workspace for Pfaffian
-    PFAPACK_dskpfa(&uplo, &mthd, &N, work_pfaffian, &ldim, &qwork_pf,
+    PFAPACK_dskpfa(&uplo_pfa, &mthd, &N, work_pfaffian, &ldim, &qwork_pf,
                   iwork, &qwork_pf, &lwork_pf, &info);
     if (info != 0) {
         free(initial_buffer);
@@ -543,7 +772,7 @@ int skpfa_batched_4d_d_with_inverse(
     }
 
     // Query optimal workspace for inverse
-    dgetri_(&N, work_matrix, &ldim, ipiv, &qwork_inv, &lwork_inv, &info);
+    dgetri_(&N, work_pfaffian, &ldim, ipiv, &qwork_inv, &lwork_inv, &info);
     if (info != 0) {
         free(initial_buffer);
         return info;
@@ -564,11 +793,10 @@ int skpfa_batched_4d_d_with_inverse(
         double *current_matrix = A_batch + idx * matrix_size;
         double *current_inverse = inverses + idx * matrix_size;
 
-        // Transpose matrix for Pfaffian computation
-        transpose_matrix(current_matrix, work_pfaffian, N);
+        memcpy(work_pfaffian, current_matrix, matrix_size * sizeof(double));
 
         // Compute Pfaffian
-        PFAPACK_dskpfa(&uplo, &mthd, &N, work_pfaffian, &ldim, &pfaffians[idx],
+        PFAPACK_dskpfa(&uplo_pfa, &mthd, &N, work_pfaffian, &ldim, &pfaffians[idx],
                       iwork, work, &lwork, &info);
         if (info != 0) {
             free(work);
@@ -576,19 +804,27 @@ int skpfa_batched_4d_d_with_inverse(
             return info;
         }
 
-        if (fabs(pfaffians[idx]) > 1e-12) {
-            // Transpose matrix again for inverse computation
-            transpose_matrix(current_matrix, work_matrix, N);
+        // Sign correction: pf(-A) = (-1)^(N/2) * pf(A), needed because we pass
+        // row-major data to column-major PFAPACK which interprets A as A^T = -A.
+        if (((N / 2) & 1) != 0) {
+            pfaffians[idx] = -pfaffians[idx];
+        }
 
-            // Ensure the full matrix is filled (assuming skew-symmetric property)
+        if (fabs(pfaffians[idx]) > 1e-12) {
+            if (current_inverse != current_matrix) {
+                memcpy(current_inverse, current_matrix, matrix_size * sizeof(double));
+            }
+
+            // Ensure the full matrix is filled (assuming skew-symmetric property).
             for (int i = 0; i < N; i++) {
                 for (int j = i + 1; j < N; j++) {
-                    work_matrix[j + i * N] = -work_matrix[i + j * N];
+                    current_inverse[(size_t)j * (size_t)N + (size_t)i] =
+                        -current_inverse[(size_t)i * (size_t)N + (size_t)j];
                 }
             }
 
-            // Compute LU decomposition
-            dgetrf_(&N, &N, work_matrix, &ldim, ipiv, &info);
+            // Compute LU decomposition and inverse in-place.
+            dgetrf_(&N, &N, current_inverse, &ldim, ipiv, &info);
             if (info != 0) {
                 free(work);
                 free(initial_buffer);
@@ -596,15 +832,14 @@ int skpfa_batched_4d_d_with_inverse(
             }
 
             // Compute inverse
-            dgetri_(&N, work_matrix, &ldim, ipiv, work, &lwork, &info);
+            dgetri_(&N, current_inverse, &ldim, ipiv, work, &lwork, &info);
             if (info != 0) {
                 free(work);
                 free(initial_buffer);
                 return info;
             }
-
-            // Transpose back the inverse to C order
-            transpose_matrix(work_matrix, current_inverse, N);
+        } else {
+            memset(current_inverse, 0, matrix_size * sizeof(double));
         }
     }
 


### PR DESCRIPTION
## Summary

Optimizes batched Pfaffian computation in the C interface, achieving **~28% speedup** on many-small-matrix workloads.

**Key changes:**

- **Workspace reuse**: Allocate LAPACK workspace once per batch instead of per matrix
- **Transpose elimination**: For `_with_inverse` functions, pass row-major data directly to column-major PFAPACK using the identity pf(-A) = (-1)^(N/2) * pf(A), avoiding 3 transpose operations per matrix
- **In-place inverse**: Compute inverse directly in output buffer
- **Consistent singular handling**: All `_with_inverse` variants now zero the inverse when Pfaffian ≈ 0
- **Overflow protection**: Added `(size_t)` casts for large batches
- **Code cleanup**: Fixed mixed indentation, removed unused variables/macros

**Performance (local M1 Max, serial):**

| Workload | Before | After | Improvement |
|----------|--------|-------|-------------|
| Tomography (256×33, 64×64) | 1.842s | 1.811s | ~1.7% |
| Many-small (262144×5, 8×8) | 0.501s | 0.358s | **~28.5%** |

The many-small workload benefits most because workspace allocation overhead was a significant fraction of per-matrix time.

## Test plan

- [x] All 27 tests pass locally
- [ ] CI tests pass
- [ ] CI benchmarks show improvement vs baseline