### PR TITLE
Fuse swap-negate on middle band in pivot interchange

### DIFF
--- a/NOT_MERGED.md
+++ b/NOT_MERGED.md
@@ -1,0 +1,43 @@
+# Why This Branch Was Not Merged
+
+**Branch:** `fused-swap-negate`
+**Date:** January 2026
+**Decision:** Do not merge
+
+## What It Does
+
+Fuses the three-call pivot interchange idiom:
+```
+swap → negate column segment → scale row segment by -1
+```
+into a single `ZSWAPNEG_MIX` / `DSWAPNEG_MIX` kernel that performs the swap-and-negate in one memory pass instead of three.
+
+## Why It Wasn't Merged
+
+The middle-band work being fused is O(M) per pivot, while the rank-2 update is O(K²) per step. The fraction of time attributable to "pivot bookkeeping" falls like 1/K as soon as K > ~12.
+
+**Benchmark results at AFQMC-relevant sizes (n ∈ [16, 64]):**
+- ±3% swings, including small regressions at n=16 complex
+- Statistically indistinguishable from noise
+- Sometimes the wrong sign
+
+This is consistent with optimizing a cold-ish path where second-order effects (instruction cache layout, call-site inlining, BLAS quirks) dominate.
+
+## Trade-off Analysis
+
+**Costs:**
+- Adds bespoke mixed-stride kernels in both real and complex paths
+- Nonstandard pattern (vs familiar LAPACK-style BLAS composition)
+- Future contributors must re-derive the transform mentally
+- Takes ownership of corner-case behavior across compilers/platforms
+
+**Benefits:**
+- Algebraically correct
+- Reduces memory passes (3 → 1)
+- Locally elegant
+
+**Verdict:** "Performance-neutral but more code" is a net loss in a numerics library unless deleting complexity elsewhere.
+
+## If You Want to Move the Needle
+
+The only remaining lever that changes the Amdahl ceiling (rather than shaving the remainder) is **semantics**: an in-place batched entry point that deletes the copy, or size-specialized copy paths for fixed n. Everything else is fighting over O(K) terms in code dominated by O(K²) updates and compulsory data motion.

--- a/external/fortran/dskr2.f
+++ b/external/fortran/dskr2.f
@@ -357,3 +357,21 @@
    10 CONTINUE
       RETURN
       END
+
+      SUBROUTINE DSWAPNEG_MIX(M, X, Y, LDY)
+*     Internal: fused swap-and-negate for mixed stride vectors
+*     X is unit-stride column segment of length M
+*     Y is strided row segment with stride LDY
+*     Result: X(i) <- -Y(1+(i-1)*LDY), Y(1+(i-1)*LDY) <- -X(i)_old
+      INTEGER M, LDY, I, IY
+      DOUBLE PRECISION X(*), Y(*), T
+      IF (M.LE.0) RETURN
+      IY = 1
+      DO 10 I = 1, M
+          T = X(I)
+          X(I) = -Y(IY)
+          Y(IY) = -T
+          IY = IY + LDY
+   10 CONTINUE
+      RETURN
+      END

--- a/external/fortran/dsktf2.f
+++ b/external/fortran/dsktf2.f
@@ -170,8 +170,8 @@
       EXTERNAL           LSAME, IDAMAX_U1
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           DSCAL_U1, DSWAP_U1, DNEG_U1, DSKR2_U1, DSKR2_L1,
-     $                   DSWAP, DSCAL, XERBLA
+      EXTERNAL           DSCAL_U1, DSWAP_U1, DSKR2_U1, DSKR2_L1,
+     $                   DSWAPNEG_MIX, DSWAP, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, MAX
@@ -235,13 +235,12 @@
 
                IF( KP .NE. KK ) THEN
                   CALL DSWAP_U1( KP-1, A( 1, KK ), A( 1, KP ))
-                  CALL DSWAP( KK-KP-1, A( KP+1, KK ), 1,
+*     Fused swap-negate on middle band: replaces DSWAP+DNEG+DSCAL
+                  CALL DSWAPNEG_MIX( KK-KP-1, A( KP+1, KK ),
      $                 A( KP, KP+1 ), LDA )
+                  A(KP, KK) = -A(KP, KK)
 
                   CALL DSWAP( N-K+1, A( KK, K), LDA, A( KP, K), LDA)
-
-                  CALL DNEG_U1(KK-KP, A(KP, KK))
-                  CALL DSCAL(KK-KP-1, -ONE, A(KP, KP+1), LDA)
                END IF
 
 *     Update the leading submatrix A(1:K-2, 1:K-2) in a rank 2 update
@@ -290,13 +289,12 @@
      $                    A( KP+1, KP ) )
                   END IF
 
-                  CALL DSWAP( KP-KK-1, A( KK+1, KK ), 1,
+*     Fused swap-negate on middle band: replaces DSWAP+DNEG+DSCAL
+                  CALL DSWAPNEG_MIX( KP-KK-1, A( KK+1, KK ),
      $                 A( KP, KK+1 ), LDA )
+                  A(KP, KK) = -A(KP, KK)
 
                   CALL DSWAP( K, A( KK, 1), LDA, A( KP, 1), LDA)
-
-                  CALL DNEG_U1(KP-KK, A(KK+1, KK))
-                  CALL DSCAL(KP-KK-1, -ONE, A(KP, KK+1), LDA)
                END IF
 
 *     Update the trailing submatrix A(K+2:N, K+2:N) in a rank 2 update

--- a/external/fortran/zskr2.f
+++ b/external/fortran/zskr2.f
@@ -359,3 +359,21 @@
    10 CONTINUE
       RETURN
       END
+
+      SUBROUTINE ZSWAPNEG_MIX(M, X, Y, LDY)
+*     Internal: fused swap-and-negate for mixed stride vectors
+*     X is unit-stride column segment of length M
+*     Y is strided row segment with stride LDY
+*     Result: X(i) <- -Y(1+(i-1)*LDY), Y(1+(i-1)*LDY) <- -X(i)_old
+      INTEGER M, LDY, I, IY
+      DOUBLE COMPLEX X(*), Y(*), T
+      IF (M.LE.0) RETURN
+      IY = 1
+      DO 10 I = 1, M
+          T = X(I)
+          X(I) = -Y(IY)
+          Y(IY) = -T
+          IY = IY + LDY
+   10 CONTINUE
+      RETURN
+      END

--- a/external/fortran/zsktf2.f
+++ b/external/fortran/zsktf2.f
@@ -172,8 +172,8 @@
       EXTERNAL           LSAME, IZAMAX_U1
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           ZSCAL_U1, ZSWAP_U1, ZNEG_U1, ZSKR2_U1, ZSKR2_L1,
-     $                   ZSWAP, ZSCAL, XERBLA
+      EXTERNAL           ZSCAL_U1, ZSWAP_U1, ZSKR2_U1, ZSKR2_L1,
+     $                   ZSWAPNEG_MIX, ZSWAP, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, MAX, SQRT
@@ -237,13 +237,12 @@
 
                IF( KP .NE. KK ) THEN
                   CALL ZSWAP_U1( KP-1, A( 1, KK ), A( 1, KP ))
-                  CALL ZSWAP( KK-KP-1, A( KP+1, KK ), 1,
+*     Fused swap-negate on middle band: replaces ZSWAP+ZNEG+ZSCAL
+                  CALL ZSWAPNEG_MIX( KK-KP-1, A( KP+1, KK ),
      $                 A( KP, KP+1 ), LDA )
+                  A(KP, KK) = -A(KP, KK)
 
                   CALL ZSWAP( N-K+1, A( KK, K), LDA, A( KP, K), LDA)
-
-                  CALL ZNEG_U1(KK-KP, A(KP, KK))
-                  CALL ZSCAL(KK-KP-1, -ONE, A(KP, KP+1), LDA)
                END IF
 
 *     Update the leading submatrix A(1:K-2, 1:K-2) in a rank 2 update
@@ -292,13 +291,12 @@
      $                    A( KP+1, KP ) )
                   END IF
 
-                  CALL ZSWAP( KP-KK-1, A( KK+1, KK ), 1,
+*     Fused swap-negate on middle band: replaces ZSWAP+ZNEG+ZSCAL
+                  CALL ZSWAPNEG_MIX( KP-KK-1, A( KK+1, KK ),
      $                 A( KP, KK+1 ), LDA )
+                  A(KP, KK) = -A(KP, KK)
 
                   CALL ZSWAP( K, A( KK, 1), LDA, A( KP, 1), LDA)
-
-                  CALL ZNEG_U1(KP-KK, A(KK+1, KK))
-                  CALL ZSCAL(KP-KK-1, -ONE, A(KP, KK+1), LDA)
                END IF
 
 *     Update the trailing submatrix A(K+2:N, K+2:N) in a rank 2 update


### PR DESCRIPTION
## Summary

Replaces the three-pass swap+negate pattern on the middle band during pivot interchange with a single fused kernel that performs `(x, y) → (-y, -x)` in one traversal.

## Details

In the unblocked Parlett-Reid factorization (`*SKTF2`), when pivoting rows/columns KP and KK (with KP < KK), the middle band consists of:
- Column segment: `A(KP+1:KK-1, KK)` — unit stride, length M = KK-KP-1
- Row segment: `A(KP, KP+1:KK-1)` — stride LDA, length M

The skew-symmetric interchange rule requires:
```
x ← -y_old
y ← -x_old  
A(KP, KK) ← -A(KP, KK)
```

**Before (3 passes):**
```fortran
CALL DSWAP(M, col_segment, 1, row_segment, LDA)   ! pass 1: swap
CALL DNEG_U1(M+1, col_segment)                     ! pass 2: negate column
CALL DSCAL(M, -ONE, row_segment, LDA)              ! pass 3: negate row
```

**After (1 pass + scalar):**
```fortran
CALL DSWAPNEG_MIX(M, col_segment, row_segment, LDA)  ! fused: swap-and-negate-both
A(KP, KK) = -A(KP, KK)                                ! scalar negate
```

## Why this is safe

1. **Numerically exact**: The only arithmetic is sign-bit toggle (multiply by -1). In IEEE-754, this is exact — no new rounding pathways.

2. **No aliasing**: The two segments occupy disjoint addresses `A(KP+i, KK)` and `A(KP, KP+i)` for KP < KK in the stored triangle.

3. **M > 0 guard**: When M = 0 (adjacent indices), the middle band is empty and only the scalar flip applies.

## Performance

Benchmarks show this is performance-neutral (within ±3% noise), which is expected: the middle band is a small fraction of total interchange time, and many pivots have small M. The value is structural — deleting redundant memory traversals shifts the bottleneck toward the remaining strided operations and the semantic buffer copy.

## Files changed

- `dskr2.f` / `zskr2.f`: Added `DSWAPNEG_MIX` / `ZSWAPNEG_MIX` internal kernels
- `dsktf2.f` / `zsktf2.f`: Updated UPPER and LOWER branches to use fused kernel

🤖 Generated with [Claude Code](https://claude.ai/code)